### PR TITLE
Adding supporting to GoCD version 18.7.0

### DIFF
--- a/src/main/java/com/microfocus/adm/almoctane/ciplugins/gocd/dto/GoVersion.java
+++ b/src/main/java/com/microfocus/adm/almoctane/ciplugins/gocd/dto/GoVersion.java
@@ -1,0 +1,55 @@
+/*
+ * (c) Copyright 2018 Micro Focus or one of its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.microfocus.adm.almoctane.ciplugins.gocd.dto;
+
+import com.google.gson.annotations.SerializedName;
+
+public class GoVersion {
+
+
+	@SerializedName("version")
+	private String version;
+	@SerializedName("build_number")
+	private String buildNumber;
+	@SerializedName("full_version")
+	private String fullVersion;
+
+	public String getVersion() {
+		return version;
+	}
+
+	public void setVersion(String version) {
+		this.version = version;
+	}
+
+	public String getBuildNumber() {
+		return buildNumber;
+	}
+
+	public void setBuildNumber(String buildNumber) {
+		this.buildNumber = buildNumber;
+	}
+
+	public String getFullVersion() {
+		return fullVersion;
+	}
+
+	public void setFullVersion(String fullVersion) {
+		this.fullVersion = fullVersion;
+	}
+}

--- a/src/main/java/com/microfocus/adm/almoctane/ciplugins/gocd/plugin/converter/OctaneSCMDataBuilder.java
+++ b/src/main/java/com/microfocus/adm/almoctane/ciplugins/gocd/plugin/converter/OctaneSCMDataBuilder.java
@@ -45,19 +45,19 @@ public class OctaneSCMDataBuilder {
 					if (materialRevision.getModifications() != null) {
 						scmData.setCommits(new ArrayList<SCMCommit>());
 						for (GoModification modification : materialRevision.getModifications()) {
-							List<SCMChange> changes = new ArrayList<>();
-							SCMChange change = DTOFactory.getInstance().newDTO(SCMChange.class);
-							change.setFile("test1.java");
-							change.setType("edit");
-							changes.add(change);
+//							List<SCMChange> changes = new ArrayList<>();
+//							SCMChange change = DTOFactory.getInstance().newDTO(SCMChange.class);
+//							change.setFile(null);
+//							change.setType("edit");
+//							changes.add(change);
 
 							scmData.getCommits().add(DTOFactory.getInstance().newDTO(SCMCommit.class)
 								.setUser(modification.getUserName())
 								.setUserEmail(modification.getEmailAddress())
 								.setComment(modification.getComment())
 								.setRevId(modification.getRevision())
-								.setTime(modification.getModifiedTime())
-								.setChanges(changes));
+								.setTime(modification.getModifiedTime()));
+//								.setChanges(changes));
 						}
 					}
 				}

--- a/src/main/java/com/microfocus/adm/almoctane/ciplugins/gocd/service/GoGetAPIVersion.java
+++ b/src/main/java/com/microfocus/adm/almoctane/ciplugins/gocd/service/GoGetAPIVersion.java
@@ -15,45 +15,39 @@
  *
  */
 
-
 package com.microfocus.adm.almoctane.ciplugins.gocd.service;
 
 import com.google.gson.Gson;
 import com.microfocus.adm.almoctane.ciplugins.gocd.dto.GoPipelineConfig;
 import com.microfocus.adm.almoctane.ciplugins.gocd.dto.GoVersion;
 import com.microfocus.adm.almoctane.ciplugins.gocd.util.GoApiUtil;
+import com.microfocus.adm.almoctane.ciplugins.gocd.util.Streams;
 import com.thoughtworks.go.plugin.api.logging.Logger;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.HttpGet;
-import com.microfocus.adm.almoctane.ciplugins.gocd.util.Streams;
 
 import java.io.IOException;
 import java.net.URLEncoder;
 
-/**
- * This class encapsulates the API call to get an complete pipeline configuration from Go.
- * This API service is available since Go Version 15.3.0
- * @see <a href="https://api.gocd.org/current/#get-pipeline-config">Get Pipeline Config</a>
- */
-public class GoGetPipelineConfig {
+public class GoGetAPIVersion {
 
-	private static final Logger Log = Logger.getLoggerFor(GoGetPipelineConfig.class);
+	private static final Logger Log = Logger.getLoggerFor(GoGetAPIVersion.class);
 
 	private final GoApiClient goApiClient;
 
-	public GoGetPipelineConfig(GoApiClient goApiClient) {
+	public GoGetAPIVersion(GoApiClient goApiClient) {
 		this.goApiClient = goApiClient;
 	}
 
-	public GoPipelineConfig get(final String pipelineName) {
+	public GoVersion get() {
 		try {
-			HttpGet request = new HttpGet(GoApiUtil.PIPELINE_CONFIG_API + URLEncoder.encode(pipelineName, "UTF-8"));
-			request.addHeader("Accept", GoApiUtil.getAcceptHeader(GoApiUtil.PIPELINE_CONFIG_API,goApiClient));
+			HttpGet request = new HttpGet(GoApiUtil.GO_VERSION_API);
+			request.addHeader("Accept", "application/vnd.go.cd.v1+json");
 			HttpResponse response = goApiClient.execute(request);
 			if (response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
 				String content = Streams.readAsString(response.getEntity().getContent());
-				return new Gson().fromJson(content, GoPipelineConfig.class);
+				return new Gson().fromJson(content, GoVersion.class);
 			} else {
 				Log.error("Request got HTTP-" + response.getStatusLine().getStatusCode());
 			}

--- a/src/main/java/com/microfocus/adm/almoctane/ciplugins/gocd/util/GoApiUtil.java
+++ b/src/main/java/com/microfocus/adm/almoctane/ciplugins/gocd/util/GoApiUtil.java
@@ -1,0 +1,79 @@
+/*
+ * (c) Copyright 2018 Micro Focus or one of its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.microfocus.adm.almoctane.ciplugins.gocd.util;
+
+import com.microfocus.adm.almoctane.ciplugins.gocd.dto.GoVersion;
+import com.microfocus.adm.almoctane.ciplugins.gocd.service.GoApiClient;
+import com.microfocus.adm.almoctane.ciplugins.gocd.service.GoGetAPIVersion;
+
+public class GoApiUtil {
+
+	private static String GO_VERSION;
+	private static final String defaultAcceptHeader = "application/vnd.go.cd.v6+json";
+	private static final String defaultGoVersion = "18.7.0";
+
+	public static final String PIPELINE_CONFIG_API = "/go/api/admin/pipelines/";
+	public static final String GO_VERSION_API = "/go/api/version/";
+
+	public static synchronized void setGoVersion(GoApiClient goApiClient) {
+		if(GoApiUtil.GO_VERSION == null) {
+			GoVersion goVersion = new GoGetAPIVersion(goApiClient).get();
+			if (goVersion != null && goVersion.getVersion() != null && !goVersion.getVersion().isEmpty()) {
+				GoApiUtil.GO_VERSION = goVersion.getVersion();
+			} else {
+				GoApiUtil.GO_VERSION = defaultGoVersion;
+			}
+		}
+	}
+
+	public static String getAcceptHeader(String api, GoApiClient apiClient){
+
+		setGoVersion(apiClient);
+		if(PIPELINE_CONFIG_API.equalsIgnoreCase(api)){
+
+			if(versionCompare(GO_VERSION,"18.7.0") >= 0 ) {
+				return "application/vnd.go.cd.v6+json";
+			} else if (versionCompare(GO_VERSION, "18.7.0") <0 && versionCompare(GO_VERSION,"17.12.0" ) >=0){
+				return "application/vnd.go.cd.v5+json";
+			} else {
+				return "application/vnd.go.cd.v4+json";
+			}
+		}
+
+		return defaultAcceptHeader;
+	}
+
+
+	public static int versionCompare(String str1, String str2) {
+		String[] vals1 = str1.split("\\.");
+		String[] vals2 = str2.split("\\.");
+		int i = 0;
+		// set index to first non-equal ordinal or length of shortest version string
+		while (i < vals1.length && i < vals2.length && vals1[i].equals(vals2[i])) {
+			i++;
+		}
+		// compare first non-equal ordinal number
+		if (i < vals1.length && i < vals2.length) {
+			int diff = Integer.valueOf(vals1[i]).compareTo(Integer.valueOf(vals2[i]));
+			return Integer.signum(diff);
+		}
+		// the strings are equal or one string is a substring of the other
+		// e.g. "1.2.3" = "1.2.3" or "1.2.3" < "1.2.3.4"
+		return Integer.signum(vals1.length - vals2.length);
+	}
+}

--- a/src/main/resources/plugin.xml
+++ b/src/main/resources/plugin.xml
@@ -20,7 +20,7 @@
 <go-plugin id="microfocus.adm.octane.ciplugins.gocd" version="1">
 	<about>
 		<name>ALM Octane GoCD CI Plugin</name>
-		<version>1.0</version>
+		<version>1.0.3</version>
 		<target-go-version>17.9.0</target-go-version>
 		<description>Allows integration of GoCD with MicroFocus ALM Octane: making pipelines and test results accessible in MicroFocus ALM Octane.</description>
 		<vendor>


### PR DESCRIPTION
internal system: octane defect #710042: [GoCD] the plugin doesn’t work with the new version of GoCD -  18.7.0